### PR TITLE
Parametrictraits

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,33 @@ arguments cannot be used for trait dispatch. Also, the default values assigned
 in the `@traitdispatch` method will override any default values assigned in the
 `@traitmethod` or `@forwardtraitmethod` methods.
 
+### Parametric types
+
+Parametric types may be used as traits and trait dispatch will correctly propagate
+the type parameters. When composing a type from parametric types, the name of
+the field should not take into account the type parameters. But the type parameters
+still need to be considered in the type definition. That is:
+
+```julia
+@contains TC{T{T1,S1}} struct bar{T1,S1} end
+```
+is equivalent to:
+
+```julia
+struct bar{T1,S1}
+  fieldT::T{T1,S1}
+end
+@hastraits bar{T1,S1} TC{T{T1,S1}}
+```
+
+Note that the `T1`s and `S1`s must coincide within the type definition and
+within the `@hastrait` macro. Type parameters may also be used in methods
+modified by `@traitdispatch`, `@traitmethod` or `@forwardtraitmethod` and they
+will be respected in the generated methods.
+
 ## How does this work?
 
-This is an implementation of so-called Tim Holy's Traits inspired on the packages
-SimpleTraits.jl and Traitor.jl.
+This is an implementation of inspired on the packages SimpleTraits.jl and Traitor.jl.
 
 `@traitdispatch` will takes a function signature and generates a method where each argument qualified with `::::` is converted into a type parameter in the method signature. The body of the generated method is a call to the same function but with
 an extra argument for each trait used for dispatch. These arguments are calls to

--- a/src/ForwardMultiTraits.jl
+++ b/src/ForwardMultiTraits.jl
@@ -49,9 +49,6 @@ macro contains(args...)
   traits = args[1:(end-1)]
   def = args[end]
   name = def.args[2]
-  if name isa Expr
-    name = name.args[1]
-  end
   hastraits = :()
   # Generate the fields and the hastrait statements
   for trait in traits
@@ -80,9 +77,6 @@ macro contains_kw(args...)
   traits = args[1:(end-1)]
   def = args[end]
   name = def.args[2]
-  if name isa Expr
-    name = name.args[1]
-  end
   hastraits = :()
   # Generate the fields and the hastrait statements
   for trait in traits

--- a/src/MultiTraits.jl
+++ b/src/MultiTraits.jl
@@ -105,17 +105,7 @@ end
 Add to a type definition the implementation of several traits.
 """
 macro implements(args...)
-  length(args) == 1 && error("Must provide traits and type definition")
-  traits = args[1:(end-1)]
-  def = args[end]
-  name = def.args[2]
-  hastraits = :()
-  # Generate the fields and the hastrait statements
-  for trait in traits
-    traitclass = trait.args[1]
-    traittype = trait.args[2]
-    hastraits = :($hastraits; ModularTypes.@hastrait $name $traitclass{$traittype})
-  end
+  def, hastraits = implements_struct(args)
   return esc(quote
     $def
     $hastraits
@@ -129,22 +119,25 @@ Add to a type definition the implementation of several traits.. The type definit
   can use all the features from the `@with_kw` macro of the package `Parameters`
 """
 macro implements_kw(args...)
-  length(args) == 1 && error("Must provide traits and type definition")
-  traits = args[1:(end-1)]
-  def = args[end]
-  name = def.args[2]
-  if name isa Expr
-    name = name.args[1]
-  end
-  hastraits = :()
-  # Generate the fields and the hastrait statements
-  for trait in traits
-    traitclass = trait.args[1]
-    traittype = trait.args[2]
-    hastraits = :($hastraits; ModularTypes.@hastrait $name $traitclass{$traittype})
-  end
+  def, hastraits = implements_struct(args)
   return esc(quote
     Parameters.@with_kw $def
     $hastraits
   end)
+end
+
+
+function implements_struct(args)
+    length(args) == 1 && error("Must provide traits and type definition")
+    traits = args[1:(end-1)]
+    def = args[end]
+    name = def.args[2]
+    hastraits = :()
+    # Generate the fields and the hastrait statements
+    for trait in traits
+      traitclass = trait.args[1]
+      traittype = trait.args[2]
+      hastraits = :($hastraits; ModularTypes.@hastrait $name $traitclass{$traittype})
+    end
+    return def, hastraits
 end

--- a/src/MultiTraits.jl
+++ b/src/MultiTraits.jl
@@ -5,13 +5,15 @@
 Declare that type `typ` implements trait `trait`. A trait is declared as `traitclass{trait}`
 where `traitclass` is the trait class that `trait` belongs to.
 """
-macro hastrait(typ, trait)
-    if trait isa Expr && trait.head == :curly && length(trait.args) == 2
-      class = trait.args[1]
-      trait = trait.args[2]
-      return esc(:($class(::Type{$typ}) = $trait))
+macro hastrait(typ, traitdecl)
+    if  MacroTools.@capture(traitdecl, class_{trait_})
+      if MacroTools.@capture(typ, name_{pars__})
+          return esc(:($class(::Type{$typ}) where {$(pars...)} = $trait))
+      else
+          return esc(:($class(::Type{$typ}) = $trait))
+      end
     else
-      error("Trait was not correctly specified")
+      error("Trait was not specified correctly")
     end
 end
 

--- a/src/MultiTraits.jl
+++ b/src/MultiTraits.jl
@@ -109,9 +109,6 @@ macro implements(args...)
   traits = args[1:(end-1)]
   def = args[end]
   name = def.args[2]
-  if name isa Expr
-    name = name.args[1]
-  end
   hastraits = :()
   # Generate the fields and the hastrait statements
   for trait in traits

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,18 +104,12 @@ function splitannotation(ex)
 end
 
 # Deal with trait types that are not visible and required module prefixes
-function cleantype(cleantyp)
-    if cleantyp isa Expr && cleantyp.head == :.
-        cleantyp = cleantyp.args[2] # No matter how many nesting modules this works
-        if cleantyp isa Expr && cleantyp.head == :quote
-          cleantyp = cleantyp.args[1]
-        elseif cleantyp isa QuoteNode
-          cleantyp = cleantyp.value
-        end
-    end
-    if cleantyp isa Symbol
-        return cleantyp
+# Also deal with parametric types
+function cleantype(ex)
+    if MacroTools.@capture(ex, (M_.name_{pars__}) | (name_{pars__}) |
+                                     (M_.name_) | (name_))
+        return name
     else
-        error("I could not parse correctly the trait type ", cleantyp)
+        error("I could not parse correctly the trait type ", ex)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using Base.Test
 
 include("test_multitraits.jl")
 include("test_forwardmultitraits.jl")
+include("test_parametrictypes.jl")
 include("test_others.jl")

--- a/test/test_parametrictypes.jl
+++ b/test/test_parametrictypes.jl
@@ -41,8 +41,8 @@ end
 
 ### Single parameter ###
 @hastrait PMT.impl{T} PMT.TC{PMT.bar{T}}
-tf = PMT.impl(1.0)
-ti = PMT.impl(1)
+tf = PMT.impl(one(Float64))
+ti = PMT.impl(one(Int64))
 @test PMT.TC(typeof(tf)) == PMT.bar{Float64}
 @test PMT.TC(typeof(ti)) == PMT.bar{Int64}
 
@@ -53,8 +53,8 @@ ti = PMT.impl(1)
 
 ### Multiple parameters ###
 @hastrait PMT.impl2{T,S} PMT.TC{PMT.bar2{T,S}}
-tf2 = PMT.impl2(1.0,1)
-ti2 = PMT.impl2(1,1.0)
+tf2 = PMT.impl2(one(Float64),one(Int64))
+ti2 = PMT.impl2(one(Int64),one(Float64))
 @test PMT.TC(typeof(tf2)) == PMT.bar2{Float64, Int64}
 @test PMT.PMT.TC(typeof(ti2)) == PMT.bar2{Int64, Float64}
 
@@ -63,15 +63,15 @@ ti2 = PMT.impl2(1,1.0)
 @test pfoo2(PMT.bar2(1,1.0)) == pfoo2(PMT.impl2(1,1.0))
 
 # Implementing parametric traits
-tf3 = PMT.impl3(1.0,1)
-ti3 = PMT.impl3(1,1.0)
+tf3 = PMT.impl3(one(Float64),one(Int64))
+ti3 = PMT.impl3(one(Int64),one(Float64))
 @test PMT.TC(typeof(tf3)) == PMT.bar2{Float64, Int64}
 @test PMT.TC(typeof(ti3)) == PMT.bar2{Int64, Float64}
 
 
 # Containing parametric traits
-tf4 = PMT.impl4(PMT.bar2(1.0,1))
-ti4 = PMT.impl4(PMT.bar2(1,1.0))
+tf4 = PMT.impl4(PMT.bar2(one(Float64),one(Int64)))
+ti4 = PMT.impl4(PMT.bar2(one(Int64),one(Float64)))
 @test PMT.TC(typeof(tf4)) == PMT.bar2{Float64, Int64}
 @test PMT.TC(typeof(ti4)) == PMT.bar2{Int64, Float64}
 

--- a/test/test_parametrictypes.jl
+++ b/test/test_parametrictypes.jl
@@ -42,13 +42,6 @@ ti2 = impl2(1,1.0)
 @test TC(typeof(ti2)) == bar2{Int64, Float64}
 
 # Implementing parametric traits
-
-# Type to be used as trait
-struct bar2{T,S}
-  x::T
-  y::S
-end
-# Type that implements a parametric trait
 @implements TC{bar2{T1,S1}} struct impl3{T1,S1}
   x::T1
   y::S1
@@ -58,3 +51,12 @@ tf3 = impl3(1.0,1)
 ti3 = impl3(1,1.0)
 @test TC(typeof(tf3)) == bar2{Float64, Int64}
 @test TC(typeof(ti3)) == bar2{Int64, Float64}
+
+
+# Containing parametric traits
+@contains TC{bar2{T1,S1}} struct impl4{T1,S1} end
+
+tf4 = impl4(bar2(1.0,1))
+ti4 = impl4(bar2(1,1.0))
+@test TC(typeof(tf4)) == bar2{Float64, Int64}
+@test TC(typeof(ti4)) == bar2{Int64, Float64}

--- a/test/test_parametrictypes.jl
+++ b/test/test_parametrictypes.jl
@@ -1,62 +1,80 @@
 using ModularTypes
 using Base.Test
 
+module PMT
+    using ModularTypes
+    # Trait class
+    struct TC end
+
+    ### Single parameter ###
+    # Type to be used as trait
+    struct bar{T}
+      x::T
+    end
+    # Type that implements a trait
+    struct impl{T}
+      x::T
+    end
+
+    ### Multiple parameters ###
+    # Type to be used as trait
+    struct bar2{T,S}
+      x::T
+      y::S
+    end
+    # Type that implements a trait
+    struct impl2{T1,S1}
+      x::T1
+      y::S1
+    end
+
+    # Implementing parametric traits
+    @implements TC{bar2{T1,S1}} struct impl3{T1,S1}
+      x::T1
+      y::S1
+    end
+
+    # Containing parametric traits
+    @contains TC{bar2{T1,S1}} struct impl4{T1,S1} end
+end
+
+
 ### Single parameter ###
+@hastrait PMT.impl{T} PMT.TC{PMT.bar{T}}
+tf = PMT.impl(1.0)
+ti = PMT.impl(1)
+@test PMT.TC(typeof(tf)) == PMT.bar{Float64}
+@test PMT.TC(typeof(ti)) == PMT.bar{Int64}
 
-# Trait class
-struct TC end
-# Type to be used as trait
-struct bar{T}
-  x::T
-end
-# Type that implements a trait
-struct impl{T}
-  x::T
-end
-
-@hastrait impl{T} TC{bar{T}}
-tf = impl(1.0)
-ti = impl(1)
-@test TC(typeof(tf)) == bar{Float64}
-@test TC(typeof(ti)) == bar{Int64}
-
+@traitdispatch pfoo(x::::PMT.TC)
+@traitmethod function pfoo(x::::PMT.bar{T})::DataType where {T} T end
+@test pfoo(PMT.bar(1)) == pfoo(PMT.impl(1))
 
 
 ### Multiple parameters ###
+@hastrait PMT.impl2{T,S} PMT.TC{PMT.bar2{T,S}}
+tf2 = PMT.impl2(1.0,1)
+ti2 = PMT.impl2(1,1.0)
+@test PMT.TC(typeof(tf2)) == PMT.bar2{Float64, Int64}
+@test PMT.PMT.TC(typeof(ti2)) == PMT.bar2{Int64, Float64}
 
-# Type to be used as trait
-struct bar2{T,S}
-  x::T
-  y::S
-end
-# Type that implements a trait
-struct impl2{T1,S1}
-  x::T1
-  y::S1
-end
-
-@hastrait impl2{T,S} TC{bar2{T,S}}
-tf2 = impl2(1.0,1)
-ti2 = impl2(1,1.0)
-@test TC(typeof(tf2)) == bar2{Float64, Int64}
-@test TC(typeof(ti2)) == bar2{Int64, Float64}
+@traitdispatch pfoo2(x::::PMT.TC)
+@traitmethod function pfoo2(x::::PMT.bar2{T,S})::DataType where {T,S} S end
+@test pfoo2(PMT.bar2(1,1.0)) == pfoo2(PMT.impl2(1,1.0))
 
 # Implementing parametric traits
-@implements TC{bar2{T1,S1}} struct impl3{T1,S1}
-  x::T1
-  y::S1
-end
-
-tf3 = impl3(1.0,1)
-ti3 = impl3(1,1.0)
-@test TC(typeof(tf3)) == bar2{Float64, Int64}
-@test TC(typeof(ti3)) == bar2{Int64, Float64}
+tf3 = PMT.impl3(1.0,1)
+ti3 = PMT.impl3(1,1.0)
+@test PMT.TC(typeof(tf3)) == PMT.bar2{Float64, Int64}
+@test PMT.TC(typeof(ti3)) == PMT.bar2{Int64, Float64}
 
 
 # Containing parametric traits
-@contains TC{bar2{T1,S1}} struct impl4{T1,S1} end
+tf4 = PMT.impl4(PMT.bar2(1.0,1))
+ti4 = PMT.impl4(PMT.bar2(1,1.0))
+@test PMT.TC(typeof(tf4)) == PMT.bar2{Float64, Int64}
+@test PMT.TC(typeof(ti4)) == PMT.bar2{Int64, Float64}
 
-tf4 = impl4(bar2(1.0,1))
-ti4 = impl4(bar2(1,1.0))
-@test TC(typeof(tf4)) == bar2{Float64, Int64}
-@test TC(typeof(ti4)) == bar2{Int64, Float64}
+@traitdispatch pfoo4(x::::PMT.TC)
+@forwardtraitmethod function pfoo4(x::::PMT.bar2{T,S})::DataType where {T,S} S end
+@test pfoo4(PMT.bar2(1,1.0)) == pfoo4(PMT.impl4(PMT.bar2(1,1.0)))

--- a/test/test_parametrictypes.jl
+++ b/test/test_parametrictypes.jl
@@ -30,9 +30,9 @@ struct bar2{T,S}
   y::S
 end
 # Type that implements a trait
-struct impl2{T,S}
-  x::T
-  y::S
+struct impl2{T1,S1}
+  x::T1
+  y::S1
 end
 
 @hastrait impl2{T,S} TC{bar2{T,S}}
@@ -40,3 +40,21 @@ tf2 = impl2(1.0,1)
 ti2 = impl2(1,1.0)
 @test TC(typeof(tf2)) == bar2{Float64, Int64}
 @test TC(typeof(ti2)) == bar2{Int64, Float64}
+
+# Implementing parametric traits
+
+# Type to be used as trait
+struct bar2{T,S}
+  x::T
+  y::S
+end
+# Type that implements a parametric trait
+@implements TC{bar2{T1,S1}} struct impl3{T1,S1}
+  x::T1
+  y::S1
+end
+
+tf3 = impl3(1.0,1)
+ti3 = impl3(1,1.0)
+@test TC(typeof(tf3)) == bar2{Float64, Int64}
+@test TC(typeof(ti3)) == bar2{Int64, Float64}

--- a/test/test_parametrictypes.jl
+++ b/test/test_parametrictypes.jl
@@ -1,0 +1,42 @@
+using ModularTypes
+using Base.Test
+
+### Single parameter ###
+
+# Trait class
+struct TC end
+# Type to be used as trait
+struct bar{T}
+  x::T
+end
+# Type that implements a trait
+struct impl{T}
+  x::T
+end
+
+@hastrait impl{T} TC{bar{T}}
+tf = impl(1.0)
+ti = impl(1)
+@test TC(typeof(tf)) == bar{Float64}
+@test TC(typeof(ti)) == bar{Int64}
+
+
+
+### Multiple parameters ###
+
+# Type to be used as trait
+struct bar2{T,S}
+  x::T
+  y::S
+end
+# Type that implements a trait
+struct impl2{T,S}
+  x::T
+  y::S
+end
+
+@hastrait impl2{T,S} TC{bar2{T,S}}
+tf2 = impl2(1.0,1)
+ti2 = impl2(1,1.0)
+@test TC(typeof(tf2)) == bar2{Float64, Int64}
+@test TC(typeof(ti2)) == bar2{Int64, Float64}


### PR DESCRIPTION
Allow parametric types to be used as traits and propagate the type parameters through dispatch.